### PR TITLE
Clarify requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,11 @@
+# Uncomment if using dataproxy with MySQL database(s)
+# MySQL-python==1.2.5
+
+# Uncomment if using dataproxy with Microsoft SQL Server database(s)
+# pymssql==2.1.1
+
+# The PostgreSQL driver (psycopg2) is already installed with CKAN,
+# so we do not need to require it again.
+
+# Use simple-crypt to encrypt passwords
 -e git+https://github.com/andrewcooke/simple-crypt.git@bb8c85128d4fff0d448e524f8acebb99b777cc38#egg=simple-crypt
-MySQL-python==1.2.5
-pymssql==2.1.1


### PR DESCRIPTION
The line in the README about requirements.txt was a little sparse, so I added more explanation in the file itself, Gemfile-style. Commented out requirements, so that users have to un-comment requirements based on their use case. Also explains why we don't need to require the PostgreSQL driver here, and why NOT to comment out simple-crypt.
