### PR TITLE
Add schema support & filtering

### DIFF
--- a/ckanext/dataproxy/controllers/search.py
+++ b/ckanext/dataproxy/controllers/search.py
@@ -79,7 +79,11 @@ class SearchController(ApiController):
         fields   = request_data.get('fields',   None) # Not yet implemented
         sort     = request_data.get('sort',     None)
 
-        table_fields = self._get_fields(table, fields=fields.split(','))
+        if fields is not None:
+            table_fields = self._get_fields(table, fields=fields.split(','))
+        else:
+            table_fields = self._get_fields(table)
+        
 
         if limit is not None:
             select_query = select_query.limit(limit)

--- a/ckanext/dataproxy/plugin.py
+++ b/ckanext/dataproxy/plugin.py
@@ -5,7 +5,12 @@ import ckan.plugins.toolkit as tk
 from ckanext.dataproxy.logic.action.create import dataproxy_resource_create
 from ckanext.dataproxy.logic.action.update import dataproxy_resource_update
 
-if float(__version__) >= 2.3:
+# When __version__ is a patch release like '2.3.1'
+# or worse, '2.3.1b', get the minor point release.
+minor   = '.'.join(__version__.split('.')[0:2]) #=> '2.3'
+version = float(minor)
+
+if version >= 2.3:
     from ckanext.reclineview.plugin import ReclineViewBase
     from ckan.lib.helpers import resource_view_get_fields
 
@@ -48,7 +53,7 @@ class DataProxyPlugin(p.SingletonPlugin):
     p.implements(p.IConfigurer)
     p.implements(p.IRoutes, inherit=True)
     
-    if float(__version__) < 2.3:
+    if version < 2.3:
         #Mask dataproxy resources as datastore ones for recline to render
         p.implements(p.IResourceController, inherit=True)
 


### PR DESCRIPTION
Add schema support: can store table and schema together in table as 'schema_name.table_name'. The filters param in `datastore_search` was throwing an error, claiming `filters` was a unicode object and could therefore not be iterated upon. Fixed that by casting it to JSON.
