### PR TITLE
fix for datapusher problem with dataproxy, the check for "resource_id…

### DIFF
--- a/ckanext/dataproxy/controllers/search.py
+++ b/ckanext/dataproxy/controllers/search.py
@@ -34,10 +34,12 @@ class SearchController(ApiController):
         """Routes dataproxy type resources to dataproxy_search method, else performs 'datastore_search' action"""
         #TODO: No access control checks for dataproxy resources!
         request_data = self._get_request_data(try_url_params=True)
-        resource = Resource.get(request_data['resource_id'])
-        if resource is not None and resource.url_type == 'dataproxy':
-            pylons.response.headers['Content-Type'] = 'application/json;charset=utf-8'
-            return self.dataproxy_search(request_data, resource)
+        log.info('{}'.format(request_data))
+        if 'resource_id' in request_data:
+            resource = Resource.get(request_data['resource_id'])
+            if resource is not None and resource.url_type == 'dataproxy':
+                pylons.response.headers['Content-Type'] = 'application/json;charset=utf-8'
+                return self.dataproxy_search(request_data, resource)
 
         #Default action otherwise
         return self.action('datastore_search', ver=3)


### PR DESCRIPTION
fix for datapusher problem with dataproxy, the check for "resource_id" should not affect any other behavior since it would break

This was a problem we were having with datapusher not being able to get the data to push.

This fix should have a minimal effect, because the code would have thrown a KeyError if it got request_data without "resource_id" beforehand. Now if that key is not present it will go to the default action.